### PR TITLE
Remove readline.createInterface

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -354,6 +354,7 @@ exports.handler = async (event, context) => {
         continue;
       }
     }
+    batches = [];
     console.log(`Successfully put ${count} events in ${batch_count} batches`);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,41 @@
-'use strict';
+"use strict";
 
-const readline = require('readline');
-const stream = require('stream');
-const url = require('url');
+const url = require("url");
 
-const zlib = require('zlib');
-const {
-    promisify,
-} = require('util');
+const zlib = require("zlib");
+const { promisify } = require("util");
 const gunzipAsync = promisify(zlib.gunzip);
 
-const aws = require('aws-sdk');
+const aws = require("aws-sdk");
+const Sentry = require("@sentry/serverless");
+
+const s3 = new aws.S3({
+  apiVersion: "2006-03-01",
+});
+const cloudWatchLogs = new aws.CloudWatchLogs({
+  apiVersion: "2014-03-28",
+});
 
 //specifying the log group and the log stream name for CloudWatch Logs
 const logGroupName = process.env.LOG_GROUP_NAME;
+
+if (!logGroupName) {
+  console.error("Invalid log group name");
+  process.exit(1);
+}
+
 const loadBalancerType = process.env.LOAD_BALANCER_TYPE;
 const plaintextLogs = process.env.PLAINTEXT_LOGS;
 
 if (process.env.SENTRY_DSN) {
-    Sentry.AWSLambda.init({
-        dsn: process.env.process.env.SENTRY_DSN,
-        tracesSampleRate: 0.0,
-    });
-}else{
-    console.log('No SENTRY_DSN environment variable. Skipping Sentry initialization.');
+  Sentry.AWSLambda.init({
+    dsn: process.env.SENTRY_DSN,
+    tracesSampleRate: 0.0,
+  });
+} else {
+  console.log(
+    "No SENTRY_DSN environment variable. Skipping Sentry initialization."
+  );
 }
 
 const MAX_BATCH_SIZE = 1048576; // maximum size in bytes of Log Events (with overhead) per invocation of PutLogEvents
@@ -31,313 +43,332 @@ const MAX_BATCH_COUNT = 10000; // maximum number of Log Events per invocation of
 const LOG_EVENT_OVERHEAD = 26; // bytes of overhead per Log Event
 
 const fields = {
-    application: [
-        "type",
-        "time",
-        "elb",
-        "client:port",
-        "target:port",
-        "request_processing_time",
-        "target_processing_time",
-        "response_processing_time",
-        "elb_status_code",
-        "target_status_code",
-        "received_bytes",
-        "sent_bytes",
-        "request",
-        "user_agent",
-        "ssl_cipher",
-        "ssl_protocol",
-        "target_group_arn",
-        "trace_id",
-        "domain_name",
-        "chosen_cert_arn",
-        "matched_rule_priority",
-        "request_creation_time",
-        "actions_executed",
-        "redirect_url",
-        "error_reason",
-        "target:port_list",
-        "target_status_code_list"
-    ],
-    classic: [
-        "time",
-        "elb",
-        "client:port",
-        "backend:port",
-        "request_processing_time",
-        "backend_processing_time",
-        "response_processing_time",
-        "elb_status_code",
-        "backend_status_code",
-        "received_bytes",
-        "sent_bytes",
-        "request",
-        "user_agent",
-        "ssl_cipher",
-        "ssl_protocol"
-    ],
-    network: [
-        "type",
-        "version",
-        "time",
-        "elb",
-        "listener",
-        "client:port",
-        "destination:port",
-        "connection_time",
-        "tls_handshake_time",
-        "received_bytes",
-        "sent_bytes",
-        "incoming_tls_alert",
-        "chosen_cert_arn",
-        "chosen_cert_serial",
-        "tls_cipher",
-        "tls_protocol_version",
-        "tls_named_group",
-        "domain_name",
-        "alpn_fe_protocol",
-        "alpn_be_protocol",
-        "alpn_client_preference_list"
-    ]
+  application: [
+    "type",
+    "time",
+    "elb",
+    "client:port",
+    "target:port",
+    "request_processing_time",
+    "target_processing_time",
+    "response_processing_time",
+    "elb_status_code",
+    "target_status_code",
+    "received_bytes",
+    "sent_bytes",
+    "request",
+    "user_agent",
+    "ssl_cipher",
+    "ssl_protocol",
+    "target_group_arn",
+    "trace_id",
+    "domain_name",
+    "chosen_cert_arn",
+    "matched_rule_priority",
+    "request_creation_time",
+    "actions_executed",
+    "redirect_url",
+    "error_reason",
+    "target:port_list",
+    "target_status_code_list",
+  ],
+  classic: [
+    "time",
+    "elb",
+    "client:port",
+    "backend:port",
+    "request_processing_time",
+    "backend_processing_time",
+    "response_processing_time",
+    "elb_status_code",
+    "backend_status_code",
+    "received_bytes",
+    "sent_bytes",
+    "request",
+    "user_agent",
+    "ssl_cipher",
+    "ssl_protocol",
+  ],
+  network: [
+    "type",
+    "version",
+    "time",
+    "elb",
+    "listener",
+    "client:port",
+    "destination:port",
+    "connection_time",
+    "tls_handshake_time",
+    "received_bytes",
+    "sent_bytes",
+    "incoming_tls_alert",
+    "chosen_cert_arn",
+    "chosen_cert_serial",
+    "tls_cipher",
+    "tls_protocol_version",
+    "tls_named_group",
+    "domain_name",
+    "alpn_fe_protocol",
+    "alpn_be_protocol",
+    "alpn_client_preference_list",
+  ],
+};
+
+function portField(fieldName, element, parsed) {
+  const field = fieldName.split(":")[0];
+  const [ip, port] = element.split(":");
+  if (ip === "-1") parsed[field] = parseInt(ip);
+  else parsed[field] = ip;
+
+  if (port) parsed[`${field}_port`] = parseInt(port);
+  else parsed[`${field}_port`] = -1;
+}
+
+// Functions that mutate the parsed object
+const fieldFunctions = {
+  request: (fieldName, element, parsed) => {
+    const [request_method, request_uri, request_http_version] =
+      element.split(/\s+/);
+    parsed.request_method = request_method;
+    parsed.request_uri = request_uri;
+    parsed.request_http_version = request_http_version;
+    const parsedUrl = url.parse(request_uri);
+    parsed.request_uri_scheme = parsedUrl.protocol;
+    parsed.request_uri_host = parsedUrl.hostname;
+    if (parsedUrl.port) parsed.request_uri_port = parseInt(parsedUrl.port);
+    parsed.request_uri_path = parsedUrl.pathname;
+    parsed.request_uri_query = parsedUrl.query;
+  },
+  "target:port": portField,
+  "client:port": portField,
+  "backend:port": portField,
+};
+
+function getS3Object(Bucket, Key) {
+  console.log(`Retrieving ${Bucket}/${Key}`);
+  return s3
+    .getObject({
+      Bucket,
+      Key,
+    })
+    .promise();
+}
+
+async function createLogGroupIfNotExists() {
+  console.log(`Checking Log Group ${logGroupName} exists`);
+  const result = await cloudWatchLogs
+    .describeLogGroups({
+      logGroupNamePrefix: logGroupName,
+    })
+    .promise();
+  if (!result.logGroups[0]) {
+    console.log(`Log Group ${logGroupName} creating`);
+    await cloudWatchLogs
+      .createLogGroup({
+        logGroupName,
+      })
+      .promise();
+  } else {
+    console.log(`Log Group ${logGroupName} exists`);
+  }
+}
+
+async function unpackLogData(s3object) {
+  console.log(`Unpacking log data for ${loadBalancerType} load balancer`);
+  if (loadBalancerType === "classic") return s3object.Body.toString("ascii");
+  else {
+    const uncompressedLogBuffer = await gunzipAsync(s3object.Body);
+    return uncompressedLogBuffer.toString("ascii");
+  }
+}
+
+function parseLine(line) {
+  console.log("Parsing log line");
+  const parsed = {};
+  let x = 0;
+  let end = false;
+  let withinQuotes = false;
+  let element = "";
+  for (const c of line + " ") {
+    if (end) {
+      if (element) {
+        const fieldName = fields[loadBalancerType][x];
+
+        if (element.match(/^\d+.?\d*$/)) element = Number(element);
+
+        if (fieldFunctions[fieldName])
+          fieldFunctions[fieldName](fieldName, element, parsed);
+
+        parsed[fieldName] = element;
+
+        element = "";
+        x++;
+      }
+      end = false;
+    }
+
+    if (c.match(/^\s$/) && !withinQuotes) end = true;
+
+    if (c === '"') {
+      if (withinQuotes) end = true;
+      withinQuotes = !withinQuotes;
+    } else if (!end) element += c;
+  }
+  return parsed;
+}
+
+async function getLogStreamSequenceToken(logStreamName) {
+  console.log(`Checking Log Streams ${logGroupName}/${logStreamName}`);
+  let currentStream;
+  const cwlDescribeStreams = await cloudWatchLogs
+    .describeLogStreams({
+      logGroupName,
+      logStreamNamePrefix: logStreamName,
+    })
+    .promise();
+
+  if (cwlDescribeStreams.logStreams[0]) {
+    console.log(`Log Stream ${logGroupName}/${logStreamName} exist. Reusing`);
+    currentStream = cwlDescribeStreams.logStreams[0];
+  } else {
+    console.log(`Creating Log Stream ${logGroupName}/${logStreamName}`);
+    await cloudWatchLogs
+      .createLogStream({
+        logGroupName,
+        logStreamName,
+      })
+      .promise();
+    const cwlDescribeCreatedStream = await cloudWatchLogs
+      .describeLogStreams({
+        logGroupName: logGroupName,
+        logStreamNamePrefix: logStreamName,
+      })
+      .promise();
+    currentStream = cwlDescribeCreatedStream.logStreams[0];
+  }
+
+  return currentStream.uploadSequenceToken;
 }
 
 exports.handler = async (event, context) => {
-    const s3 = new aws.S3({
-        apiVersion: '2006-03-01'
+  const logStreamName = context.logStreamName;
+  var batches = [];
+  var batch = [];
+  var batch_size = 0;
+
+  await createLogGroupIfNotExists();
+
+  let sequenceToken = await getLogStreamSequenceToken(logStreamName);
+
+  function readLines(line) {
+    // mutate batch, batches, batch_size
+    let ts;
+    switch (loadBalancerType) {
+      case "classic":
+        ts = line.split(" ", 1)[0];
+        break;
+      case "application":
+        ts = line.split(" ", 2)[1];
+        break;
+      case "network":
+        ts = line.split(" ", 3)[2];
+        break;
+      default:
+        console.error("Invalid load balancer type");
+        process.exit(1);
+    }
+
+    const tval = Date.parse(ts);
+
+    if (!plaintextLogs) line = JSON.stringify(parseLine(line));
+
+    const event_size = line.length + LOG_EVENT_OVERHEAD;
+    batch_size += event_size;
+    if (batch_size >= MAX_BATCH_SIZE || batch.length >= MAX_BATCH_COUNT) {
+      // start a new batch
+      batches.push(batch);
+      batch = [];
+      batch_size = event_size;
+    }
+
+    batch.push({
+      message: line,
+      timestamp: tval,
     });
-    const cloudWatchLogs = new aws.CloudWatchLogs({
-        apiVersion: '2014-03-28'
+  }
+
+  async function sendBatch(logEvents) {
+    // mutate sequenceToken
+    console.log(`Sending batch to ${logStreamName}`);
+    const putLogEventParams = {
+      logEvents,
+      logGroupName,
+      logStreamName,
+      sequenceToken,
+    };
+
+    // sort the events in ascending order by timestamp as required by PutLogEvents
+    console.log("Sorting events");
+    putLogEventParams.logEvents.sort((a, b) => {
+      if (a.timestamp > b.timestamp) return 1;
+      if (a.timestamp < b.timestamp) return -1;
+      return 0;
     });
 
-    const logStreamName = context.logStreamName;
-    const bucket = event.Records[0].s3.bucket.name;
-    const key = decodeURIComponent(event.Records[0].s3.object.key.replace(/\+/g, ' '));
+    console.log("Calling PutLogEvents");
+    const cwPutLogEvents = await cloudWatchLogs
+      .putLogEvents(putLogEventParams)
+      .promise();
+    console.log(
+      `Success in putting ${putLogEventParams.logEvents.length} events`
+    );
+    if (
+      cwPutLogEvents.rejectedLogEventsInfo?.expiredLogEventEndIndex ||
+      cwPutLogEvents.rejectedLogEventsInfo?.tooNewLogEventStartIndex ||
+      cwPutLogEvents.rejectedLogEventsInfo?.tooOldLogEventEndIndex
+    ) {
+      console.warn(
+        `Failed in putting events (expiredLogEventEndIndex=${cwPutLogEvents.rejectedLogEventsInfo?.expiredLogEventEndIndex},tooNewLogEventStartIndex=${cwPutLogEvents.rejectedLogEventsInfo?.tooNewLogEventStartIndex},tooOldLogEventEndIndex=${cwPutLogEvents.rejectedLogEventsInfo?.tooOldLogEventEndIndex}`
+      );
+    }
+    sequenceToken = cwPutLogEvents.nextSequenceToken;
+  }
+
+  async function sendBatches() {
+    batches.push(batch);
+    console.log(
+      `Finished batching, pushing ${batches.length} batches to CloudWatch`
+    );
+    let batch_count = 0;
+    let count = 0;
+    for (let i = 0; i < batches.length; i++) {
+      const logEvents = batches[i];
+      try {
+        if (!logEvents) continue;
+        await sendBatch(logEvents);
+        ++batch_count;
+        count += logEvents.length;
+      } catch (err) {
+        Sentry.captureException(err);
+        console.log("Error sending batch: ", err, err.stack);
+        continue;
+      }
+    }
+    console.log(`Successfully put ${count} events in ${batch_count} batches`);
+  }
+
+  for (const record of event.Records) {
+    const bucket = record.s3.bucket.name;
+    const key = decodeURIComponent(record.s3.object.key.replace(/\+/g, " "));
     const s3object = await getS3Object(bucket, key);
     const logData = await unpackLogData(s3object);
-    await createLogGroupIfNotExists();
-
-    let sequenceToken = await getLogStreamSequenceToken(logStreamName);
-
-    console.log('Parsing log lines');
-    var batches = [];
-    var batch = [];
-    var batch_size = 0;
-    var bufferStream = new stream.PassThrough();
-    bufferStream.end(logData);
-
-    var rl = readline.createInterface({
-        input: bufferStream
-    });
-
-    function portField(fieldName, element, parsed) {
-        const field = fieldName.split(':')[0];
-        const [ip, port] = element.split(':');
-        if (ip === '-1') parsed[field] = parseInt(ip)
-        else parsed[field] = ip;
-
-        if (port) parsed[`${field}_port`] = parseInt(port)
-        else parsed[`${field}_port`] = -1
+    console.log("Parsing log lines");
+    for (const line of logData.trim().split("\n")) {
+      readLines(line);
     }
-
-    // Functions that mutate the parsed object
-    const fieldFunctions = {
-        "request": (fieldName, element, parsed) => {
-            const [request_method, request_uri, request_http_version] = element.split(/\s+/)
-            parsed.request_method = request_method
-            parsed.request_uri = request_uri
-            parsed.request_http_version = request_http_version
-            const parsedUrl = url.parse(request_uri)
-            parsed.request_uri_scheme = parsedUrl.protocol
-            parsed.request_uri_host = parsedUrl.hostname
-            if (parsedUrl.port) parsed.request_uri_port = parseInt(parsedUrl.port)
-            parsed.request_uri_path = parsedUrl.pathname
-            parsed.request_uri_query = parsedUrl.query
-        },
-        "target:port": portField,
-        "client:port": portField,
-        "backend:port": portField,
-    }
-
-    function readLines(line) {
-        let ts;
-        switch (loadBalancerType) {
-            case 'classic':
-                ts = line.split(' ', 1)[0];
-                break;
-            case 'application':
-                ts = line.split(' ', 2)[1];
-                break;
-            case 'network':
-                ts = line.split(' ', 3)[2];
-                break;
-            default:
-                console.error('Invalid load balancer type');
-                process.exit(1);
-        }
-
-        var tval = Date.parse(ts);
-
-        if (!plaintextLogs) line = JSON.stringify(parseLine(line));
-        
-        var event_size = line.length + LOG_EVENT_OVERHEAD;
-        batch_size += event_size;
-        if (batch_size >= MAX_BATCH_SIZE ||
-            batch.length >= MAX_BATCH_COUNT) {
-            // start a new batch
-            batches.push(batch);
-            batch = [];
-            batch_size = event_size;
-        }
-
-        batch.push({
-            message: line,
-            timestamp: tval,
-        });
-    }
-
-    function parseLine(line) {
-        console.log('Parsing log line')
-        const parsed = {}
-        let x = 0
-        let end = false
-        let withinQuotes = false
-        let element = ''
-        for (const c of line + ' ') {
-            if (end) {
-                if (element) {
-                    const fieldName = fields[loadBalancerType][x]
-
-                    if (element.match(/^\d+.?\d*$/)) element = Number(element)
-
-                    if (fieldFunctions[fieldName]) fieldFunctions[fieldName](fieldName, element, parsed)
-
-                    parsed[fieldName] = element;
-
-                    element = '';
-                    x++;
-                }
-                end = false;
-            };
-
-            if (c.match(/^\s$/) && !withinQuotes) end = true;
-
-            if (c === '"') {
-                if (withinQuotes) end = true
-                withinQuotes = !withinQuotes;
-            }
-            else if (!end) element += c;
-        }
-        return parsed
-    }
-
-    async function sendBatch(logEvents, seqToken) {
-        console.log(`Sending batch to ${logStreamName}`);
-        var putLogEventParams = {
-            logEvents,
-            logGroupName,
-            logStreamName,
-            sequenceToken: seqToken,
-        }
-
-        // sort the events in ascending order by timestamp as required by PutLogEvents
-        console.log('Sorting events');
-        putLogEventParams.logEvents.sort((a, b) => {
-            if (a.timestamp > b.timestamp) return 1;
-            if (a.timestamp < b.timestamp) return -1;
-            return 0;
-        });
-
-        console.log('Calling PutLogEvents')
-        const cwPutLogEvents = await cloudWatchLogs.putLogEvents(putLogEventParams).promise();
-        console.log(`Success in putting ${putLogEventParams.logEvents.length} events`);
-        return cwPutLogEvents.nextSequenceToken
-
-        // try {
-
-        // } catch (err) {
-        //     console.log('Error during put log events: ', err, err.stack);
-        //     return sequenceToken;
-        // }
-    }
-
-    async function sendBatches() {
-        batches.push(batch);
-        console.log(`Finished batching, pushing ${batches.length} batches to CloudWatch`);
-        let seqToken = sequenceToken;
-        for (let i = 0; i < batches.length; i++) {
-            const logEvents = batches[i];
-            var count = 0;
-            var batch_count = 0;
-            try {
-                seqToken = await sendBatch(logEvents, seqToken);
-                ++batch_count;
-                count += logEvents.length;
-            } catch (err) {
-                console.log('Error sending batch: ', err, err.stack);
-                continue;
-            }
-        }
-        console.log(`Successfully put ${count} events in ${batch_count} batches`);
-    }
-
-    async function getS3Object(Bucket, Key) {
-        console.log(`Retrieving ${Bucket}${Key}`);
-        return await s3.getObject({
-            Bucket,
-            Key,
-        }).promise();
-    }
-
-    async function unpackLogData(s3object) {
-        console.log(`Unpacking log data for ${loadBalancerType} load balancer`);
-        if (loadBalancerType === "classic") return s3object.Body.toString('ascii')
-        else {
-            const uncompressedLogBuffer = await gunzipAsync(s3object.Body);
-            return uncompressedLogBuffer.toString('ascii');
-        }
-    }
-
-    async function createLogGroupIfNotExists() {
-        console.log(`Checking Log Group ${logGroupName} exists`);
-        const result = await cloudWatchLogs.describeLogGroups({
-            logGroupNamePrefix: logGroupName,
-        }).promise();
-        if (!result.logGroups[0]) {
-            console.log(`${logGroupName} exists`);
-            await cloudWatchLogs.createLogGroup({
-                logGroupName,
-            }).promise();
-        }
-    }
-
-    async function getLogStreamSequenceToken() {
-        console.log(`Checking Log Streams ${logGroupName}/${logStreamName}`);
-        let currentStream;
-        const cwlDescribeStreams = await cloudWatchLogs.describeLogStreams({
-            logGroupName,
-            logStreamNamePrefix: logStreamName
-        }).promise();
-
-        if (cwlDescribeStreams.logStreams[0]) currentStream = cwlDescribeStreams.logStreams[0]
-        else {
-            console.log(`Creating Log Stream ${logGroupName}/${logStreamName}`);
-            await cloudWatchLogs.createLogStream({
-                logGroupName,
-                logStreamName,
-            }).promise();
-            const cwlDescribeCreatedStream = await cloudWatchLogs.describeLogStreams({
-                logGroupName: logGroupName,
-                logStreamNamePrefix: logStreamName
-            }).promise();
-            currentStream = cwlDescribeCreatedStream.logStreams[0];
-        }
-
-        return currentStream.uploadSequenceToken;
-    }
-
-    rl.on('line', await readLines);
-    rl.on('close', await sendBatches);
+    console.log("Sending batches log lines");
+    await sendBatches();
+  }
 };
 
 if (process.env.SENTRY_DSN) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,15 @@ const logGroupName = process.env.LOG_GROUP_NAME;
 const loadBalancerType = process.env.LOAD_BALANCER_TYPE;
 const plaintextLogs = process.env.PLAINTEXT_LOGS;
 
+if (process.env.SENTRY_DSN) {
+    Sentry.AWSLambda.init({
+        dsn: process.env.process.env.SENTRY_DSN,
+        tracesSampleRate: 0.0,
+    });
+}else{
+    console.log('No SENTRY_DSN environment variable. Skipping Sentry initialization.');
+}
+
 const MAX_BATCH_SIZE = 1048576; // maximum size in bytes of Log Events (with overhead) per invocation of PutLogEvents
 const MAX_BATCH_COUNT = 10000; // maximum number of Log Events per invocation of PutLogEvents
 const LOG_EVENT_OVERHEAD = 26; // bytes of overhead per Log Event
@@ -330,3 +339,7 @@ exports.handler = async (event, context) => {
     rl.on('line', await readLines);
     rl.on('close', await sendBatches);
 };
+
+if (process.env.SENTRY_DSN) {
+  exports.handler = Sentry.AWSLambda.wrapHandler(exports.handler);
+}

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ASL",
       "dependencies": {
         "@sentry/serverless": "^7.27.0",
-        "aws-sdk": "^2.814.0"
+        "aws-sdk": "^2.1277.0"
       }
     },
     "node_modules/@sentry/core": {
@@ -177,23 +177,35 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/aws-sdk": {
-      "version": "2.814.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.814.0.tgz",
-      "integrity": "sha512-empd1m/J/MAkL6d9OeRpmg9thobULu0wk4v8W3JToaxGi2TD7PIdvE6yliZKyOVAdJINhBWEBhxR4OUIHhcGbQ==",
+      "version": "2.1277.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1277.0.tgz",
+      "integrity": "sha512-cEZ0rg0j3STtLX6rba5tHMrV/KrhXKLtSleleF2IdTFzUjqRvxI54Pqc51w2D7tgAPUgEhMB4Q/ruKPqB8w+2Q==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.3.2",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
         "xml2js": "0.4.19"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -223,6 +235,18 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/cookie": {
@@ -257,6 +281,79 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "dependencies": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -274,15 +371,78 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "node_modules/jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
       }
@@ -330,13 +490,43 @@
         "querystring": "0.2.0"
       }
     },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/xml2js": {
@@ -501,19 +691,25 @@
         "debug": "4"
       }
     },
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
     "aws-sdk": {
-      "version": "2.814.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.814.0.tgz",
-      "integrity": "sha512-empd1m/J/MAkL6d9OeRpmg9thobULu0wk4v8W3JToaxGi2TD7PIdvE6yliZKyOVAdJINhBWEBhxR4OUIHhcGbQ==",
+      "version": "2.1277.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1277.0.tgz",
+      "integrity": "sha512-cEZ0rg0j3STtLX6rba5tHMrV/KrhXKLtSleleF2IdTFzUjqRvxI54Pqc51w2D7tgAPUgEhMB4Q/ruKPqB8w+2Q==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
         "ieee754": "1.1.13",
-        "jmespath": "0.15.0",
+        "jmespath": "0.16.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
         "url": "0.10.3",
-        "uuid": "3.3.2",
+        "util": "^0.12.4",
+        "uuid": "8.0.0",
         "xml2js": "0.4.19"
       }
     },
@@ -530,6 +726,15 @@
         "base64-js": "^1.0.2",
         "ieee754": "^1.1.4",
         "isarray": "^1.0.0"
+      }
+    },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
       }
     },
     "cookie": {
@@ -550,6 +755,58 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.3"
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "requires": {
+        "get-intrinsic": "^1.1.3"
+      }
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
+    },
+    "has-symbols": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
     "https-proxy-agent": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
@@ -564,15 +821,54 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
     },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-arguments": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
+      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
+    },
+    "is-generator-function": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
+      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "jmespath": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.16.0.tgz",
+      "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw=="
     },
     "lru_map": {
       "version": "0.3.3",
@@ -613,10 +909,35 @@
         "querystring": "0.2.0"
       }
     },
+    "util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      }
     },
     "xml2js": {
       "version": "0.4.19",

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1,9 +1,506 @@
 {
   "name": "aws-load-balancer-logs-to-cloudwatch",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "aws-load-balancer-logs-to-cloudwatch",
+      "version": "1.0.0",
+      "license": "ASL",
+      "dependencies": {
+        "@sentry/serverless": "^7.27.0",
+        "aws-sdk": "^2.814.0"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.27.0.tgz",
+      "integrity": "sha512-9WkHMllGNOr6S55N2HKJYJj/2mog5Kv6mjruqlcHHPSgcKFA8bjwBXJTghy6UzwtGd14cyS/X7h5AVUkvuXTMw==",
+      "dependencies": {
+        "@sentry/types": "7.27.0",
+        "@sentry/utils": "7.27.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.27.0.tgz",
+      "integrity": "sha512-wp/nbkl1vi3Lajaf9AMCxyDTJP8V4GEiyg0jaG4p3MSF3/6t0+C5Lqqp3GunQZCyXWqDrtuLvNpirtp2egsBiQ==",
+      "dependencies": {
+        "@sentry/core": "7.27.0",
+        "@sentry/types": "7.27.0",
+        "@sentry/utils": "7.27.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/serverless": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-7.27.0.tgz",
+      "integrity": "sha512-76nuP/of48LKQAU/ZJZWwMQHo0//wnLJzCRwz0VmKEciiXQYys5MmXI/Lo9ECL7OvtZoXIl+ehCf3zttCnzIPQ==",
+      "dependencies": {
+        "@sentry/node": "7.27.0",
+        "@sentry/tracing": "7.27.0",
+        "@sentry/types": "7.27.0",
+        "@sentry/utils": "7.27.0",
+        "@types/aws-lambda": "^8.10.62",
+        "@types/express": "^4.17.14",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@sentry/tracing": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.27.0.tgz",
+      "integrity": "sha512-lxAiGAajbZgZkaViwYuxavbu/c8JUp56XOYzSAi7Km9jGnTFLNF4JCoyG0INy7lXipFJiWSd0Xq3aej0Lb+Cvg==",
+      "dependencies": {
+        "@sentry/core": "7.27.0",
+        "@sentry/types": "7.27.0",
+        "@sentry/utils": "7.27.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-vapN3jchu3/WEMWQkrCOy2XDlOLj0l7IewYXKMr15Q21dlfM1QZMigU/r5rtYj5L8a2ISIHx+cRECxX5UIKH7w==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.27.0.tgz",
+      "integrity": "sha512-8e5cmjbeuxETPxPEymyyGEYlBbJO1IMveTlcxkTFySPU6nNz2oAIiqPVHv2QgFJJvRv79/i/4Tyl5gFMOW0+AA==",
+      "dependencies": {
+        "@sentry/types": "7.27.0",
+        "tslib": "^1.9.3"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/aws-lambda": {
+      "version": "8.10.109",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.109.tgz",
+      "integrity": "sha512-/ME92FneNyXQzrAfcnQQlW1XkCZGPDlpi2ao1MJwecN+6SbeonKeggU8eybv1DfKli90FAVT1MlIZVXfwVuCyg=="
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
+      "integrity": "sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.31",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.17.31",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
+      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "node_modules/@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
+      "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw=="
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "dependencies": {
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/aws-sdk": {
+      "version": "2.814.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.814.0.tgz",
+      "integrity": "sha512-empd1m/J/MAkL6d9OeRpmg9thobULu0wk4v8W3JToaxGi2TD7PIdvE6yliZKyOVAdJINhBWEBhxR4OUIHhcGbQ==",
+      "dependencies": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "dependencies": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "node_modules/jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
+    },
+    "node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "node_modules/querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "dependencies": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  },
   "dependencies": {
+    "@sentry/core": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.27.0.tgz",
+      "integrity": "sha512-9WkHMllGNOr6S55N2HKJYJj/2mog5Kv6mjruqlcHHPSgcKFA8bjwBXJTghy6UzwtGd14cyS/X7h5AVUkvuXTMw==",
+      "requires": {
+        "@sentry/types": "7.27.0",
+        "@sentry/utils": "7.27.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.27.0.tgz",
+      "integrity": "sha512-wp/nbkl1vi3Lajaf9AMCxyDTJP8V4GEiyg0jaG4p3MSF3/6t0+C5Lqqp3GunQZCyXWqDrtuLvNpirtp2egsBiQ==",
+      "requires": {
+        "@sentry/core": "7.27.0",
+        "@sentry/types": "7.27.0",
+        "@sentry/utils": "7.27.0",
+        "cookie": "^0.4.1",
+        "https-proxy-agent": "^5.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/serverless": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/serverless/-/serverless-7.27.0.tgz",
+      "integrity": "sha512-76nuP/of48LKQAU/ZJZWwMQHo0//wnLJzCRwz0VmKEciiXQYys5MmXI/Lo9ECL7OvtZoXIl+ehCf3zttCnzIPQ==",
+      "requires": {
+        "@sentry/node": "7.27.0",
+        "@sentry/tracing": "7.27.0",
+        "@sentry/types": "7.27.0",
+        "@sentry/utils": "7.27.0",
+        "@types/aws-lambda": "^8.10.62",
+        "@types/express": "^4.17.14",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/tracing": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/tracing/-/tracing-7.27.0.tgz",
+      "integrity": "sha512-lxAiGAajbZgZkaViwYuxavbu/c8JUp56XOYzSAi7Km9jGnTFLNF4JCoyG0INy7lXipFJiWSd0Xq3aej0Lb+Cvg==",
+      "requires": {
+        "@sentry/core": "7.27.0",
+        "@sentry/types": "7.27.0",
+        "@sentry/utils": "7.27.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.27.0.tgz",
+      "integrity": "sha512-vapN3jchu3/WEMWQkrCOy2XDlOLj0l7IewYXKMr15Q21dlfM1QZMigU/r5rtYj5L8a2ISIHx+cRECxX5UIKH7w=="
+    },
+    "@sentry/utils": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.27.0.tgz",
+      "integrity": "sha512-8e5cmjbeuxETPxPEymyyGEYlBbJO1IMveTlcxkTFySPU6nNz2oAIiqPVHv2QgFJJvRv79/i/4Tyl5gFMOW0+AA==",
+      "requires": {
+        "@sentry/types": "7.27.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@types/aws-lambda": {
+      "version": "8.10.109",
+      "resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.109.tgz",
+      "integrity": "sha512-/ME92FneNyXQzrAfcnQQlW1XkCZGPDlpi2ao1MJwecN+6SbeonKeggU8eybv1DfKli90FAVT1MlIZVXfwVuCyg=="
+    },
+    "@types/body-parser": {
+      "version": "1.19.2",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
+      "integrity": "sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==",
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/express": {
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.15.tgz",
+      "integrity": "sha512-Yv0k4bXGOH+8a+7bELd2PqHQsuiANB+A8a4gnQrkRWzrkKlb6KHaVvyXhqs04sVW/OWlbPyYxRgYlIXLfrufMQ==",
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.31",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.17.31",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
+      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "requires": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*"
+      }
+    },
+    "@types/mime": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
+      "integrity": "sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA=="
+    },
+    "@types/node": {
+      "version": "18.11.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.15.tgz",
+      "integrity": "sha512-VkhBbVo2+2oozlkdHXLrb3zjsRkpdnaU2bXmX8Wgle3PUi569eLRaHGlgETQHR7lLL1w7GiG3h9SnePhxNDecw=="
+    },
+    "@types/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
+    },
+    "@types/range-parser": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
+    },
+    "@types/serve-static": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.0.tgz",
+      "integrity": "sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==",
+      "requires": {
+        "@types/mime": "*",
+        "@types/node": "*"
+      }
+    },
+    "agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "requires": {
+        "debug": "4"
+      }
+    },
     "aws-sdk": {
       "version": "2.814.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.814.0.tgz",
@@ -35,10 +532,32 @@
         "isarray": "^1.0.0"
       }
     },
+    "cookie": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.2.tgz",
+      "integrity": "sha512-aSWTXFzaKWkvHO1Ny/s+ePFpvKsPnjc551iI41v3ny/ow6tBG5Vd+FuqGNhh1LxOmVzOlGUriIlOaokOvhaStA=="
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "requires": {
+        "agent-base": "6",
+        "debug": "4"
+      }
     },
     "ieee754": {
       "version": "1.1.13",
@@ -55,6 +574,16 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha512-Pn9cox5CsMYngeDbmChANltQl+5pi6XmTrraMSzhPmMBbmgcxmqWry0U3PGapCU1yB4/LqCcom7qhHZiF/jGfQ=="
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -69,6 +598,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "url": {
       "version": "0.10.3",

--- a/src/package.json
+++ b/src/package.json
@@ -18,6 +18,6 @@
   "homepage": "https://github.com/rupertbg/aws-load-balancer-logs-to-cloudwatch#readme",
   "dependencies": {
     "@sentry/serverless": "^7.27.0",
-    "aws-sdk": "^2.814.0"
+    "aws-sdk": "^2.1277.0"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -17,6 +17,7 @@
   },
   "homepage": "https://github.com/rupertbg/aws-load-balancer-logs-to-cloudwatch#readme",
   "dependencies": {
+    "@sentry/serverless": "^7.27.0",
     "aws-sdk": "^2.814.0"
   }
 }


### PR DESCRIPTION
This PR reorganizes the processing in the function.

First, the use of readline made no sense. It was neither streamed (tempting regarding memory usage) nor correct. This could cause data loss (probably related to https://github.com/rupertbg/aws-load-balancer-logs-to-cloudwatch/issues/3 ). I am surprised that the code provided initially by AWS has such errors that indicate a misunderstanding of the impact of async-await and streams in NodeJS on each other.

Moved functions that don't need to be in the handler to the global state. In the case of inner functions, I noted what outer state they modify.

Added logging information if some logs failed to be saved to CW.

Expanded logging when a stream is created and when not. This was the initial error, so we need to start seeing more.

Changed the approach to sequenceToken, which should avoid errors in this regard.

Enabled support for multiple records in a single event. The lack of support could cause data loss.
